### PR TITLE
Environment 

### DIFF
--- a/lib/beautydate_api.rb
+++ b/lib/beautydate_api.rb
@@ -10,9 +10,8 @@ require_relative 'beautydate_api/business'
 require_relative 'beautydate_api/business_payment'
 
 module BeautydateApi
-  @api_version = 'v2'
-  @endpoint = 'https://beautydate.com.br/api'
-  @staging_endpoint = ENV.fetch('BEAUTYDATE_API_STAGING_ENDPOINT', 'https://beta.beautydate.com.br/api')
+  @api_version = 'v2'.freeze
+  @endpoint = 'https://beautydate.com.br/api'.freeze
 
   class AuthenticationException < StandardError
   end
@@ -35,6 +34,10 @@ module BeautydateApi
     attr_accessor :staging
     attr_writer :api_key, :api_email, :api_password
 
+    def staging_endpoint
+      @staging_endpoint ||= ENV.fetch('BEAUTYDATE_API_STAGING_ENDPOINT', 'https://beta.beautydate.com.br/api')
+    end
+
     def api_key
       @api_key || ENV.fetch('BEAUTYDATE_API_KEY')
     end
@@ -50,7 +53,7 @@ module BeautydateApi
     def base_uri
       @staging = true if @staging.nil? # default environment
       if @staging
-        "#{@staging_endpoint}/#{@api_version}"
+        "#{staging_endpoint}/#{@api_version}"
       else
         "#{@endpoint}/#{@api_version}"
       end

--- a/lib/beautydate_api/version.rb
+++ b/lib/beautydate_api/version.rb
@@ -1,3 +1,3 @@
 module BeautydateApi
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end


### PR DESCRIPTION
Quando em modo development, usando o dotenv para carregar o .env por exemplo, faz com que a ordem de carregamento do Gemfile importante, pois se o dotenv for carregado (e inicializado) depois do require 'beautydate-api', faz o ENV ainda não conter as variáveis definidas no .env.