### PR TITLE
Adição de chamada para remoção de devices

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+BEAUTYDATE_API_KEY={{Consumer UUID that can be found in "db/seeds.rb"}}
+BEAUTYDATE_API_EMAIL={{your user email, which can also be found in "db/seeds.rb"}}
+BEAUTYDATE_API_PASSWORD={{your user password, which can also be found in "db/seeds.rb"}}
+BEAUTYDATE_API_SESSION_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+BEAUTYDATE_API_BASE_URI=https://beta.beautydate.com.br/api
 BEAUTYDATE_API_KEY={{Consumer UUID that can be found in "db/seeds.rb"}}
 BEAUTYDATE_API_EMAIL={{your user email, which can also be found in "db/seeds.rb"}}
 BEAUTYDATE_API_PASSWORD={{your user password, which can also be found in "db/seeds.rb"}}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ config/secrets.yml
 /vendor/assets/bower_components
 *.bowerrc
 bower.json
+
+# Debugger
+.byebug_history
+
+# Environment variables
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ruby:2.5.0
+MAINTAINER ti@beautydate.com
+
+RUN gem install bundler
+
+RUN mkdir /gem
+WORKDIR /gem
+
+COPY Gemfile* /gem/
+COPY *.gemspec /gem/
+COPY lib /gem/lib/
+ENV GEM_NAME beautydate_api
+
+RUN bundle install
+
+# Uncomment this line if not mounting a volume
+# COPY . /gem
+
+CMD ["bin/console"]

--- a/README.md
+++ b/README.md
@@ -16,14 +16,30 @@ $ bundle
 
 ## Desenvolvimento
 
-Faça o build da imagem:
+- Crie um arquivo `.env` a partir de `.env.example`
+```sh
+cp .env.example .env
+```
+
+- Preencha os seus dados no arquivo `.env`
+
+- Faça o build da imagem
 ```sh
 docker build . -t beautydate-sdk-ruby
 ```
 
-Rode o console com o volume montado para as alterações dos arquivos serem propagadas
+- Rode o console com o volume montado da pasta local
 ```sh
-docker run --rm -it -v $(pwd):/gem beautydate-sdk-ruby
+docker run --rm -it --env-file .env -v $(pwd):/gem beautydate-sdk-ruby
+```
+
+- Teste para verificar se está tudo funcionando
+```ruby
+BeautydateApi.staging = false
+business = BeautydateApi::Business.new
+business.id = 199
+business.refresh
+business.name # 'Barba Negra'
 ```
 
 ## Definindo a chave de acesso a API do Beauty Date

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ docker run --rm -it --env-file .env -v $(pwd):/gem beautydate-sdk-ruby
 
 - Teste para verificar se está tudo funcionando
 ```ruby
-BeautydateApi.staging = false
 business = BeautydateApi::Business.new
 business.id = 199
 business.refresh

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ E execute:
 $ bundle
 ```
 
+## Desenvolvimento
+
+Faça o build da imagem:
+```sh
+docker build . -t beautydate-sdk-ruby
+```
+
+Rode o console com o volume montado para as alterações dos arquivos serem propagadas
+```sh
+docker run --rm -it -v $(pwd):/gem beautydate-sdk-ruby
+```
+
 ## Definindo a chave de acesso a API do Beauty Date
 
 Chave do consumidor:

--- a/beautydate_api.gemspec
+++ b/beautydate_api.gemspec
@@ -5,14 +5,14 @@ require "beautydate_api/version"
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
-  s.name        = "beautydate_api"
+  s.name        = 'beautydate_api'
   s.version     = BeautydateApi::VERSION
-  s.authors     = ["Fábio Tomio"]
-  s.email       = ["fabiotomio@gmail.com"]
-  s.homepage    = "https://beautydate.com.br"
-  s.summary     = "Summary of BeautydateApi."
-  s.description = "Description of BeautydateApi."
-  s.license     = "MIT"
+  s.authors     = ['Tiago Guedes', 'Giovanni Bonetti']
+  s.email       = ['tiagopog@gmail.com', 'giovanni.bonetti@gmail.com']
+  s.homepage    = 'https://beautydate.com.br'
+  s.summary     = 'Summary of BeautydateApi.'
+  s.description = 'Description of BeautydateApi.'
+  s.license     = 'MIT'
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]

--- a/bin/console
+++ b/bin/console
@@ -3,5 +3,8 @@
 require 'bundler/setup'
 require 'beautydate_api'
 
+# Require external gems
+Bundler.require(:default, 'development')
+
 require 'irb'
 IRB.start

--- a/lib/beautydate_api.rb
+++ b/lib/beautydate_api.rb
@@ -11,7 +11,6 @@ require_relative 'beautydate_api/business_payment'
 
 module BeautydateApi
   @api_version = 'v2'.freeze
-  @endpoint = 'https://beautydate.com.br/api'.freeze
 
   class AuthenticationException < StandardError
   end
@@ -31,12 +30,9 @@ module BeautydateApi
   end
 
   class << self
-    attr_accessor :staging
-    attr_writer :api_key, :api_email, :api_password, :api_session_token
-
-    def staging_endpoint
-      @staging_endpoint ||= ENV.fetch('BEAUTYDATE_API_STAGING_ENDPOINT', 'https://beta.beautydate.com.br/api')
-    end
+    attr_reader :api_version
+    attr_writer :api_key, :api_email, :api_password, :api_session_token,
+                :base_uri
 
     def api_key
       @api_key || ENV.fetch('BEAUTYDATE_API_KEY')
@@ -55,12 +51,11 @@ module BeautydateApi
     end
 
     def base_uri
-      @staging = true if @staging.nil? # default environment
-      if @staging
-        "#{staging_endpoint}/#{@api_version}"
-      else
-        "#{@endpoint}/#{@api_version}"
-      end
+      "#{base_uri_without_version}/#{api_version}"
+    end
+
+    def base_uri_without_version
+      @base_uri || ENV.fetch('BEAUTYDATE_API_BASE_URI')
     end
   end
 end

--- a/lib/beautydate_api.rb
+++ b/lib/beautydate_api.rb
@@ -8,6 +8,13 @@ require_relative 'beautydate_api/api_consumer'
 require_relative 'beautydate_api/api_session'
 require_relative 'beautydate_api/business'
 require_relative 'beautydate_api/business_payment'
+require_relative 'beautydate_api/device'
+
+# TODO: Replace the lines above by:
+#
+# Require everything in lib folder, but in random order to find out during
+# development if any "require" instructions are missing in any file
+# Dir['lib/**/*.rb'].shuffle.each { |path| require path.split('lib/')[-1] }
 
 module BeautydateApi
   @api_version = 'v2'.freeze

--- a/lib/beautydate_api/api_request.rb
+++ b/lib/beautydate_api/api_request.rb
@@ -47,6 +47,7 @@ module BeautydateApi
       end
 
       def handle_response(response)
+        return if response.body.blank?
         JSON.parse(response.body)
       rescue JSON::ParserError
         raise RequestFailed

--- a/lib/beautydate_api/api_session.rb
+++ b/lib/beautydate_api/api_session.rb
@@ -3,7 +3,7 @@ module BeautydateApi
     attr_accessor :token_key, :expires_at
 
     def initialize(token_key = nil)
-      @token_key  = token_key
+      @token_key  = token_key.presence
       @expires_at = extract_expires_at
     end
 

--- a/lib/beautydate_api/device.rb
+++ b/lib/beautydate_api/device.rb
@@ -1,0 +1,13 @@
+module BeautydateApi
+  class Device < APIResource
+    def destroy(id)
+      if id.is_a?(Integer) || id.to_s =~ /\A\d+\z/
+        call('DELETE', self.class.url(id))
+      else
+        raise UnkownIdentifierError, "Missing or invalid device ID: #{id}"
+      end
+    rescue ObjectNotFound
+      false
+    end
+  end
+end

--- a/lib/beautydate_api/object.rb
+++ b/lib/beautydate_api/object.rb
@@ -48,6 +48,7 @@ module BeautydateApi
     end
 
     def update_attributes_from_result(result)
+      return if result.blank?
       set_attributes(result.dig('data', 'attributes'))
       @id = result.dig('data', 'id')
     end

--- a/lib/beautydate_api/version.rb
+++ b/lib/beautydate_api/version.rb
@@ -1,3 +1,3 @@
 module BeautydateApi
-  VERSION = '0.1.4'
+  VERSION = '1.0.0.alpha'
 end


### PR DESCRIPTION
## Objetivo
Adicionar um método para a remoção de devices com a chamada DELETE /api/v2/devices/:id.
Ele será usado na [implementação do feedback do serviço de notificações para remover device tokens inválidos](https://github.com/b2beauty/uservice-notification/pull/41).

## Entraves
Faz mais de 6 meses que não há nenhum desenvolvimento neste projeto, então tive bastante dificuldade para preparar o ambiente para começar a trabalhar na funcionalidade. Vou colocar junto as melhorias que preparei para facilitar o trabalho da próxima pessoa que mexer no projeto.

## Implementação
- [x] Montar um Dockerfile para rodar o projeto via Docker
- [x] Testar uma chamada a um salão de produção, corrigir problemas e atualizar a documentação
- [x] Simplificar a escolha de ambientes com uma variável de ambiente BEAUTYDATE_API_BASE_URI
- [x] Implementar o método para remoção de devices
- [ ] Fazer specs para o novo método
- [ ] Publicar a nova versão da gem no RubyGems (major -> 1.0.0)
